### PR TITLE
Removal of weak ciphers

### DIFF
--- a/installfullnode.sh
+++ b/installfullnode.sh
@@ -470,6 +470,9 @@ server {
     ssl_protocols TLSv1.3 TLSv1.2;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
     ssl_dhparam /etc/nginx/dhparam.pem;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
     
     # OCSP stapling
     ssl_stapling on;


### PR DESCRIPTION
Might cause issues with older browsers like these:  In testing these were reported by SSLlabs:

Safari 6 / iOS 6.0.1	Server sent fatal alert: handshake_failure
Safari 7 / iOS 7.1  R	Server sent fatal alert: handshake_failure
Safari 7 / OS X 10.9  R	Server sent fatal alert: handshake_failure
Safari 8 / iOS 8.4  R	Server sent fatal alert: handshake_failure
Safari 8 / OS X 10.10  R	Server sent fatal alert: handshake_failure
IE 11 / Win Phone 8.1  R	Server sent fatal alert: handshake_failure